### PR TITLE
Melhorias na validação do IBAN para identificar IBANs de Angola

### DIFF
--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -1,7 +1,7 @@
 library angola_validator;
 
 
-extension AngolaValidatorExntension on String {
+extension AngolaValidatorExtension on String {
   bool validateVehicleRegistration() {
     const regex = r'^[A-Z]{2}-\d{2}-\d{2}-[A-Z]{2}$|^[A-Z]{3}-\d{2}-\d{2}$';
     RegExp(regex).hasMatch(this);

--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -63,13 +63,13 @@ extension AngolaValidatorExtension on String {
       return "IBAN inválido. O código desse banco é inválido";
     }
 
-    if (_parseIBAN(iban) != 1) {
+    if (_calculateIBANChecksum(iban) != 1) {
       return "IBAN inválido, por favor insira um IBAN válido";
     }
     return '';
   }
 
-  int _parseIBAN(String iban) {
+  int _calculateIBANChecksum(String iban) {
     String ibanWithoutPrefix = iban.substring(4);
     String numericIban = ibanWithoutPrefix.replaceAll(RegExp(r'[^0-9]'), '');
 

--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -1,6 +1,5 @@
 library angola_validator;
 
-
 extension AngolaValidatorExtension on String {
   bool validateVehicleRegistration() {
     const regex = r'^[A-Z]{2}-\d{2}-\d{2}-[A-Z]{2}$|^[A-Z]{3}-\d{2}-\d{2}$';
@@ -16,7 +15,11 @@ extension AngolaValidatorExtension on String {
     }
 
     if (iban.length != 25) {
-      return "IBAN inválido, por favor insira um IBAN válido";
+      return "IBAN inválido. O tamanho deve ser de 25 caracteres";
+    }
+
+    if (!iban.startsWith("AO06")) {
+      return "IBAN inválido. Adicione o código AO06";
     }
 
     if (_parseIBAN(iban) != 1) {

--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -9,12 +9,13 @@ extension AngolaValidatorExtension on String {
   }
 
   String validateIBAN() {
+    String iban = replaceAll(".", "").replaceAll(" ", "");
+
     if (isEmpty) {
       return "IBAN inválido, por favor insira um IBAN válido";
     }
-    String iban = replaceAll(".", "").replaceAll(" ", "");
 
-    if (iban.length < 21) {
+    if (iban.length != 25) {
       return "IBAN inválido, por favor insira um IBAN válido";
     }
 

--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -7,6 +7,38 @@ extension AngolaValidatorExtension on String {
     return RegExp(regex).hasMatch(this);
   }
 
+  bool isAngolanBankCode(String bankCode) {
+    Map<String, String> angolanBanks = {
+      "BAI": "0040",
+      "BCA": "0043",
+      "BCI": "0005",
+      "BCGA": "0004",
+      "BCS": "0070",
+      "BDA": "0054",
+      "BE": "0045",
+      "BFA": "0006",
+      "BCH": "0059",
+      "BIC": "0051",
+      "BIR": "0067",
+      "BMA": "0055",
+      "BMF": "0048",
+      "BNI": "0052",
+      "BOCLB": "0071",
+      "BPC": "0010",
+      "BPG": "0064",
+      "BSOL": "0044",
+      "BVB": "0062",
+      "FNB": "0058",
+      "KEVE": "0047",
+      "SBA": "0060",
+      "SCBA": "0063",
+      "VTB": "0056",
+      "YETU": "0066"
+    };
+
+    return angolanBanks.containsValue(bankCode);
+  }
+
   String validateIBAN() {
     String iban = replaceAll(".", "").replaceAll(" ", "");
 
@@ -24,6 +56,12 @@ extension AngolaValidatorExtension on String {
 
     if (!iban.substring(4).contains(RegExp(r'^[0-9]+$'))) {
       return "IBAN inválido. Não deve conter letras após AO06";
+    }
+
+    String bankCode = iban.substring(4, 8);
+
+    if (!isAngolanBankCode(bankCode)) {
+      return "IBAN inválido. O código desse banco é inválido";
     }
 
     if (_parseIBAN(iban) != 1) {

--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -3,7 +3,6 @@ library angola_validator;
 extension AngolaValidatorExtension on String {
   bool validateVehicleRegistration() {
     const regex = r'^[A-Z]{2}-\d{2}-\d{2}-[A-Z]{2}$|^[A-Z]{3}-\d{2}-\d{2}$';
-    RegExp(regex).hasMatch(this);
     return RegExp(regex).hasMatch(this);
   }
 

--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -33,6 +33,9 @@ extension AngolaValidatorExtension on String {
   }
 
   int _parseIBAN(String iban) {
-    return int.parse(iban) % 97;
+    String ibanWithoutPrefix = iban.substring(4);
+    String numericIban = ibanWithoutPrefix.replaceAll(RegExp(r'[^0-9]'), '');
+
+    return int.parse(numericIban) % 97;
   }
 }

--- a/lib/angola_validator_extension.dart
+++ b/lib/angola_validator_extension.dart
@@ -22,6 +22,10 @@ extension AngolaValidatorExtension on String {
       return "IBAN inválido. Adicione o código AO06";
     }
 
+    if (!iban.substring(4).contains(RegExp(r'^[0-9]+$'))) {
+      return "IBAN inválido. Não deve conter letras após AO06";
+    }
+
     if (_parseIBAN(iban) != 1) {
       return "IBAN inválido, por favor insira um IBAN válido";
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
+  test: ^1.24.3
 
 
 flutter:

--- a/tests/angola_validator_extension.dart
+++ b/tests/angola_validator_extension.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import 'package:angola_validator/angola_validator_extension.dart';
+
+void main() {
+  group('Angola Validator Tests', () {
+    test(
+        'validateVehicleRegistration should return true for valid registrations',
+        () {
+      expect('AA-12-34-AA'.validateVehicleRegistration(), isTrue);
+      expect('AAA-12-34'.validateVehicleRegistration(), isTrue);
+    });
+
+    test(
+        'validateVehicleRegistration should return false for invalid registrations',
+        () {
+      expect('A-12-34-AA'.validateVehicleRegistration(), isFalse);
+      expect('AAA-12-34-A'.validateVehicleRegistration(), isFalse);
+      expect('AAA-123-45'.validateVehicleRegistration(), isFalse);
+      expect('AA-12-34-A1'.validateVehicleRegistration(), isFalse);
+    });
+
+    test('validateIBAN should return an error message for invalid IBANs', () {
+      expect(''.validateIBAN(),
+          contains('IBAN inválido, por favor insira um IBAN válido'));
+      expect('AO060040000010894244101757'.validateIBAN(),
+          contains('IBAN inválido. O tamanho deve ser de 25 caracteres'));
+      expect('AO05ABC123456789012345675'.validateIBAN(),
+          contains('IBAN inválido. Adicione o código AO06'));
+      expect('AO060ABC12345678901234567'.validateIBAN(),
+          contains('IBAN inválido. Não deve conter letras após AO06'));
+      expect('AO06009912345678901234567'.validateIBAN(),
+          contains('IBAN inválido. O código desse banco é inválido'));
+      expect('AO06004312345678901234566'.validateIBAN(),
+          contains('IBAN inválido, por favor insira um IBAN válido'));
+    });
+
+    test('validateIBAN should return an empty string for valid IBANs', () {
+      expect('AO06004000001089424410175'.validateIBAN(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
**Melhorias na validação do IBAN para identificar IBANs de Angola**

Esta PR introduz melhorias significativas na validação do IBAN para identificar IBANs pertencentes a Angola. Aqui estão as principais alterações realizadas:

- Verificação de comprimento do IBAN: Agora, o código verifica se o IBAN possui exatamente 25 caracteres.
- Verificação inicial: verificamos se o IBAN começa com o código "AO06".
- Verificação de caracteres seguintes: após o código "AO06", verificamos se apenas dígitos numéricos estão presentes.
- Refatoração da função _parseIBAN: renomeamos a função para _calculateIBANCheckSum e ajustamos os cálculos para considerar apenas os números após "AO06".
- Verificação de banco nacional: garantimos que o código do banco no IBAN pertence a um banco nacional angolano.
- Testes unitários: adicionamos testes unitários abrangentes para verificar as funções validateVehicleRegistration e validateIBAN.
- Limpeza de código: Removemos código não utilizado da função validateVehicleRegistration.